### PR TITLE
remove parameter keys not supported by modules and bucket policy action causing malformed policy error

### DIFF
--- a/modules/S3BucketBlog/fragments/s3.json
+++ b/modules/S3BucketBlog/fragments/s3.json
@@ -4,17 +4,17 @@
     "Parameters": {
         "KMSKeyAlias": {
             "Description": "The alias for your KMS key. If you will leave this field empty KMS key alias won't be created along the key.",
-            "Type": "String",
+            "Type": "String"
         },
         "ReadOnlyArn": {
             "Description": "Provide ARN of an existing Principal (role) that will be granted with read only access to the S3 bucket (e.g. 'arn:aws:iam::123456789xxx:role/myS3ROrole'). If not specified, access will be granted to current AWS account:root only. CF deployment will fail and rollback for non-existing ARN.",
             "Type": "String",
-            "Default": "",
+            "Default": ""
         },
         "ReadWriteArn": {
             "Description": "Provide ARN of an existing Principal (role) that will be granted with read and write access to the S3 bucket (e.g. 'arn:aws:iam::123456789xxx:role/myS3RWrole'). If not specified, access will be granted to current AWS account:root only. CF deployment will fail and rollback for non-existing ARN.",
             "Type": "String",
-            "Default": "",
+            "Default": ""
         }
     },
     "Resources": {

--- a/modules/S3BucketBlog/fragments/s3.json
+++ b/modules/S3BucketBlog/fragments/s3.json
@@ -5,24 +5,16 @@
         "KMSKeyAlias": {
             "Description": "The alias for your KMS key. If you will leave this field empty KMS key alias won't be created along the key.",
             "Type": "String",
-            "AllowedPattern": "^(?!aws)([a-zA-Z0-9\\-\\_\\/]){1,32}$|^$",
-            "MinLength": 0,
-            "MaxLength": 32,
-            "ConstraintDescription": "KMS key alias must be at least 1 and no more than 32 characters long, can contain lowercase and uppercase letters, numbers, hyphens, underscores and forward slashes and cannot begin with aws."
         },
         "ReadOnlyArn": {
             "Description": "Provide ARN of an existing Principal (role) that will be granted with read only access to the S3 bucket (e.g. 'arn:aws:iam::123456789xxx:role/myS3ROrole'). If not specified, access will be granted to current AWS account:root only. CF deployment will fail and rollback for non-existing ARN.",
             "Type": "String",
             "Default": "",
-            "AllowedPattern": "^(arn:aws:iam::\\d{12}:role(\\/|\\/[\\w\\!\\\"\\#\\$\\%\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~]{1,510}\\/)[\\w\\+\\=\\,\\.\\@\\-]{1,64})$|^$",
-            "ConstraintDescription": "IAM role ARN must start with arn:aws:iam::<12-digit AWS account number>:role/[<path>/]<name of role>. The name of role must be at least 1 and no more than 64 characters long, can contain lowercase letters, uppercase letters, numbers, plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-). Path is optional and must not exceed 510 characters."
         },
         "ReadWriteArn": {
             "Description": "Provide ARN of an existing Principal (role) that will be granted with read and write access to the S3 bucket (e.g. 'arn:aws:iam::123456789xxx:role/myS3RWrole'). If not specified, access will be granted to current AWS account:root only. CF deployment will fail and rollback for non-existing ARN.",
             "Type": "String",
             "Default": "",
-            "AllowedPattern": "^(arn:aws:iam::\\d{12}:role(\\/|\\/[\\w\\!\\\"\\#\\$\\%\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~]{1,510}\\/)[\\w\\+\\=\\,\\.\\@\\-]{1,64})$|^$",
-            "ConstraintDescription": "IAM role ARN must start with arn:aws:iam::<12-digit AWS account number>:role/[<path>/]<name of role>. The name of role must be at least 1 and no more than 64 characters long, can contain lowercase letters, uppercase letters, numbers, plus (+), equal (=), comma (,), period (.), at (@), underscore (_), and hyphen (-). Path is optional and must not exceed 510 characters."
         }
     },
     "Resources": {

--- a/modules/S3BucketBlog/fragments/s3.json
+++ b/modules/S3BucketBlog/fragments/s3.json
@@ -205,8 +205,7 @@
                             "Action": [
                                 "s3:GetObject",
                                 "s3:GetObjectTagging",
-                                "s3:ListBucket",
-                                "s3:ListBucketByTags"
+                                "s3:ListBucket"
                             ],
                             "Resource": [
                                 {
@@ -231,7 +230,6 @@
                                 "s3:GetObject",
                                 "s3:GetObjectTagging",
                                 "s3:ListBucket",
-                                "s3:ListBucketByTags",
                                 "s3:PutObject",
                                 "s3:PutObjectTagging"
                             ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
remove parameter keys not supported by modules to avoid confusion that they are being evaluated, remove s3 policy element causing malformed policy error (s3:ListBucketByTags)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
