### PR TITLE
Unit tests and updates for the AWSSamples::EC2::ImportKeyPair resource type (example using Python)

### DIFF
--- a/resource-types/awssamples-ec2-importkeypair/python/.coveragerc
+++ b/resource-types/awssamples-ec2-importkeypair/python/.coveragerc
@@ -1,0 +1,15 @@
+# .coveragerc - configuration file used with `pytest --cov`
+# Configuration reference: https://coverage.readthedocs.io/en/latest/config.html
+
+
+[run]
+
+# Files to omit from tests and reports
+omit =
+    # omit any __init__.py file
+    */__init__.py
+
+    # omit the models.py file
+    src/*/models.py
+    # omit tests
+    src/*/tests/*

--- a/resource-types/awssamples-ec2-importkeypair/python/.coveragerc
+++ b/resource-types/awssamples-ec2-importkeypair/python/.coveragerc
@@ -3,6 +3,7 @@
 
 
 [run]
+branch = True
 
 # Files to omit from tests and reports
 omit =
@@ -13,3 +14,7 @@ omit =
     src/*/models.py
     # omit tests
     src/*/tests/*
+
+
+[report]
+fail_under = 85

--- a/resource-types/awssamples-ec2-importkeypair/python/README.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/README.md
@@ -4,9 +4,11 @@
 
 - [Usage](#Usage)
 
-- [Unit tests](#Unit-tests)
+- [Tests](#Tests)
 
-- [Contract tests](#Contract-tests)
+  - [Unit tests](#Unit-tests)
+
+  - [Contract tests](#Contract-tests)
 
 - [Example schema and handlers](#Example-schema-and-handlers)
 
@@ -36,7 +38,11 @@ If you choose to activate and test this example resource type in your AWS accoun
   - CloudFormation will leverage the example resource type described in the template to import the public key in your account and region
 
 
-## Unit tests
+## Tests
+Example unit tests and information on how to run unit and contract tests are shown next.
+
+
+### Unit tests
 Example unit tests are available in `src/awssamples_ec2_importkeypair/tests`, and are meant to be used with [pytest](https://docs.pytest.org/) and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/).  To run example unit tests:
 
 - choose to install `pytest-cov` with `pip`; for example: `pip install pytest-cov`
@@ -44,7 +50,7 @@ Example unit tests are available in `src/awssamples_ec2_importkeypair/tests`, an
 - you should now be able to run unit tests for this example resource type; make sure to be in the same directory where this README.md file is located, and choose to run unit tests with: `pytest --cov src --cov-report term-missing`.  The `.coveragerc` configuration file (located in the same directory as this README.md file) will be used to read configuration preferences, that include omitting a number of files as part of unit test runs and reports.
 
 
-## Contract tests
+### Contract tests
 Contract tests help you validate the resource type you're developing works as you expect.  For more information, see [Testing resource types using contract tests](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html) in the AWS documentation.  You use the [test](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-cli-test.html) command of the CloudFormation CLI to run contract tests in your account: in this example, you will specify example values to create, update, delete EC2 key pair resources (named with an `example-keypair-for-contract-tests` prefix) in your account and region.  For contract tests runs, you can choose to specify an execution role that contract tests can assume; alternatively, contract tests will use your environment credentials or credentials specified in the Boto3 credentials chain.
 
 When you run contract tests, you pass in input values; for more information, see [Specifying input data for use in contract tests](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html#resource-type-test-input-data).  Contract tests for this example resource type use `create`, `update` and `invalid` input data from files in the `inputs` directory.  If you inspect create- and update-related input files content in the aforementioned directory, you will see a line such as `"PublicKeyMaterial": "{{KeyPairPublicKeyForContractTests}}",`: this line is used by contract tests to take, as an input, the public key material that you will use to run contract tests, and input data in this case is taken from a CloudFormation stack you will need to create before running contract tests.  To run contract tests for this resource type:

--- a/resource-types/awssamples-ec2-importkeypair/python/README.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/README.md
@@ -57,7 +57,7 @@ When you run contract tests, you pass in input values; for more information, see
 
 - create a CloudFormation stack using the `examples/example-template-contract-tests-input.yaml` template; for the `KeyPairPublicKey` input parameter, provide the public key material you wish to use for your contract tests.  This stack will create an [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) resource in your account and region, to store the public key material for your reference.  In the `Outputs` section of this stack, you will find an `KeyPairPublicKey` output exported as `KeyPairPublicKeyForContractTests`, which is the value contract tests in this example will read
 - run the Local Lambda Service: `sam local start-lambda`; for more information, see [Testing resource types locally using SAM](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html#resource-type-develop-test)
-- run contract tests as follows: `cfn submit --dry-run && cfn test`
+- run contract tests as follows: `cfn generate && cfn submit --dry-run && cfn test`
 - when you are done running contract tests/submitting the module, you can choose to delete the stack you created as part of this contract tests section
 
 

--- a/resource-types/awssamples-ec2-importkeypair/python/README.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/README.md
@@ -1,11 +1,24 @@
 # AWSSamples::EC2::ImportKeyPair
 
-## Overview
+- [Overview](#Overview)
 
+- [Usage](#Usage)
+
+- [Unit tests](#Unit-tests)
+
+- [Contract tests](#Contract-tests)
+
+- [Example schema and handlers](#Example-schema-and-handlers)
+
+  - [Type hints](#Type-hints)
+
+
+## Overview
 This is an example resource type for [AWS CloudFormation](https://aws.amazon.com/cloudformation/) that describes a key pair you wish to import.  For more information on creating resource types, see [Creating resource types](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-types.html) in the CloudFormation Command Line Interface documentation.
 
 
 ## Usage
+For more information on syntax usage for this example resource type, see the [docs/README.md](docs/README.md) page.
 
 If you choose to activate and test this example resource type in your AWS account:
 
@@ -13,7 +26,7 @@ If you choose to activate and test this example resource type in your AWS accoun
 - clone this repository on your workstation
 - on your workstation, change directory to the directory where this `README.md` file is located
 - register the example resource type with CloudFormation as a private extension in the AWS account and region where you want to use the resource.  As part of this process, you leverage CloudFormation to describe and create, in your account, an [AWS Identity and Access Management](https://aws.amazon.com/iam/) (IAM) role, that is assumed by CloudFormation when _Create, Read, Update, Delete, List_ (CRUDL) operations occur to manage the resource on your behalf.  The IAM role policy will include actions specified in the [handlers](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-handlers) section of the JSON schema file for the resource.  In this example, the _handlers_ section of the `awssamples-ec2-importkeypair.json` schema file describes actions such as `ec2:CreateTags`, `ec2:DeleteKeyPair`, `ec2:DeleteTags`, `ec2:DescribeKeyPairs`, `ec2:ImportKeyPair`, where applicable in relevant `create`, `read`, `update`, `delete`, and `list` handlers
-  - choose to use the [submit](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-cli-submit.html) command of the [CloudFormation CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html) to register the example resource type, e.g.: `cfn submit --set-default --region REGION_YOU_WISH_TO_USE`
+  - choose to use the [submit](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-cli-submit.html) command of the [CloudFormation CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html) to register the example resource type, e.g.: `cfn generate && cfn submit --set-default --region REGION_YOU_WISH_TO_USE`
   - verify the example resource type is registered in the account and region you chose: navigate to the AWS CloudFormation console, and from _Registry_ choose _Activated extensions_; you should find the `AWSSamples::EC2::ImportKeyPair` resource type in the _Resource types_ list
   - for more information, see [register private extensions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-register.html)
 - test the example resource by using the `examples/example-template-import-keypair.yaml` template:
@@ -21,6 +34,15 @@ If you choose to activate and test this example resource type in your AWS accoun
   - the `ssh-keygen` command you ran should produce a file called e.g., `YOUR_KEY`, that is your private key, and another file called e.g., `YOUR_KEY.pub`.  Please note the `.pub` extension in the second file, that is the public key you will import.  Open, with a text editor of your choice, the file with the `.pub` extension (public key material): you will need to copy and paste its content when specifying the public key material in the next step
   - create a CloudFormation stack off of the template mentioned earlier: specify a name for the key pair to import, and the public key material you wish to use, that is the content of the file with the `.pub` extension mentioned earlier
   - CloudFormation will leverage the example resource type described in the template to import the public key in your account and region
+
+
+## Unit tests
+Example unit tests are available in `src/awssamples_ec2_importkeypair/tests`, and are meant to be used with [pytest](https://docs.pytest.org/) and [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/).  To run example unit tests:
+
+- choose to install `pytest-cov` with `pip`; for example: `pip install pytest-cov`
+- choose to install `cloudformation-cli-python-lib` with `pip`; for example: `pip install cloudformation-cli-python-lib`
+- you should now be able to run unit tests for this example resource type; make sure to be in the same directory where this README.md file is located, and choose to run unit tests with: `pytest --cov src --cov-report term-missing`.  The `.coveragerc` configuration file (located in the same directory as this README.md file) will be used to read configuration preferences, that include omitting a number of files as part of unit test runs and reports.
+
 
 ## Contract tests
 Contract tests help you validate the resource type you're developing works as you expect.  For more information, see [Testing resource types using contract tests](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html) in the AWS documentation.  You use the [test](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-cli-test.html) command of the CloudFormation CLI to run contract tests in your account: in this example, you will specify example values to create, update, delete EC2 key pair resources (named with an `example-keypair-for-contract-tests` prefix) in your account and region.  For contract tests runs, you can choose to specify an execution role that contract tests can assume; alternatively, contract tests will use your environment credentials or credentials specified in the Boto3 credentials chain.
@@ -32,12 +54,12 @@ When you run contract tests, you pass in input values; for more information, see
 - run contract tests as follows: `cfn submit --dry-run && cfn test`
 - when you are done running contract tests/submitting the module, you can choose to delete the stack you created as part of this contract tests section
 
-## Example schema and handlers
 
+## Example schema and handlers
 For more information on this example resource type, see the following files:
 
 1. JSON schema describing the example resource: `awssamples-ec2-importkeypair.json`
-2. resource handlers for `CREATE`, `READ`, `UPDATE`, `DELETE`, `LIST` actions: `awssamples_ec2_importkeypair/handlers.py`
+2. resource handlers for `CREATE`, `READ`, `UPDATE`, `DELETE`, `LIST` actions: `src/awssamples_ec2_importkeypair/handlers.py`
 
 > Don't modify `models.py` by hand, any modifications will be overwritten when the `generate` or `package` commands are run.
 
@@ -68,6 +90,6 @@ ProgressEvent(
 
 Failures can be passed back to CloudFormation by either raising an exception from `cloudformation_cli_python_lib.exceptions`, or setting the ProgressEvent's `status` to `OperationStatus.FAILED` and `errorCode` to one of `cloudformation_cli_python_lib.HandlerErrorCode`. There is a static helper function, `ProgressEvent.failed`, for this common case.
 
-## What's with the type hints?
 
+### Type hints
 We hope they'll be useful for getting started quicker with an IDE that support type hints. Type hints are optional - if your code doesn't use them, it will still work.

--- a/resource-types/awssamples-ec2-importkeypair/python/awssamples-ec2-importkeypair.json
+++ b/resource-types/awssamples-ec2-importkeypair/python/awssamples-ec2-importkeypair.json
@@ -43,6 +43,10 @@
             "minLength": 1,
             "maxLength": 255
         },
+        "KeyType": {
+            "description": "The type of the key pair.",
+            "type": "string"
+        },
         "PublicKeyMaterial": {
             "description": "The public key material is a mandatory element.",
             "type": "string",
@@ -66,7 +70,11 @@
     ],
     "readOnlyProperties": [
         "/properties/KeyPairId",
-        "/properties/KeyFingerprint"
+        "/properties/KeyFingerprint",
+        "/properties/KeyType"
+    ],
+    "writeOnlyProperties": [
+        "/properties/PublicKeyMaterial"
     ],
     "primaryIdentifier": [
         "/properties/KeyPairId"

--- a/resource-types/awssamples-ec2-importkeypair/python/docs/README.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/docs/README.md
@@ -92,3 +92,7 @@ A Key Pair ID is automatically generated on creation and is assigned as the uniq
 
 The MD5 public key fingerprint of the imported key.
 
+#### KeyType
+
+The type of the key pair.
+

--- a/resource-types/awssamples-ec2-importkeypair/python/examples/example-template-import-keypair.yaml
+++ b/resource-types/awssamples-ec2-importkeypair/python/examples/example-template-import-keypair.yaml
@@ -1,14 +1,11 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: This template describes an example resource type for importing a key
-  pair.
+Description: This template describes an example resource type for importing a key pair.
 Parameters:
   KeyPairName:
     AllowedPattern: ^[\x00-\x7F]{1,255}$
     Default: example-key-pair
-    Description: 'Please specify the name you wish to assign to the key pair you are
-      importing.  Allowed values include ASCII characters; minimum length: 1, maximum:
-      255.'
+    Description: 'Please specify the name you wish to assign to the key pair you are importing.  Allowed values include ASCII characters; minimum length: 1, maximum: 255.'
     MaxLength: '255'
     MinLength: '1'
     Type: String
@@ -51,4 +48,7 @@ Outputs:
   KeyPairId:
     Description: The ID of the key pair you imported.
     Value: !Ref 'KeyPair'
+  KeyType:
+    Description: The type of the key pair.
+    Value: !GetAtt 'KeyPair.KeyType'
 

--- a/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_1_create.json
+++ b/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_1_create.json
@@ -1,18 +1,4 @@
 {
-  "KeyName": "example-keypair-for-contract-tests-0",
-  "PublicKeyMaterial": "{{KeyPairPublicKeyForContractTests}}",
-  "Tags": [
-    {
-      "Key": "Name",
-      "Value": "example-keypair-for-contract-tests-0"
-    },
-    {
-      "Key": "OrganizationName",
-      "Value": "ExampleBusinessUnitUpdate-0"
-    },
-    {
-      "Key": "OrganizationBusinessUnitName",
-      "Value": "ExampleOrganizationUpdate-0"
-    }
-  ]
+  "KeyName": "example-keypair-for-contract-tests-1",
+  "PublicKeyMaterial": "{{KeyPairPublicKeyForContractTests}}"
 }

--- a/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_1_update.json
+++ b/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_1_update.json
@@ -5,14 +5,6 @@
     {
       "Key": "Name",
       "Value": "example-keypair-for-contract-tests-1"
-    },
-    {
-      "Key": "OrganizationName",
-      "Value": "ExampleBusinessUnitUpdate-1"
-    },
-    {
-      "Key": "OrganizationBusinessUnitName",
-      "Value": "ExampleOrganizationUpdate-1"
     }
   ]
 }

--- a/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_2_create.json
+++ b/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_2_create.json
@@ -5,14 +5,6 @@
     {
       "Key": "Name",
       "Value": "example-keypair-for-contract-tests-2"
-    },
-    {
-      "Key": "OrganizationName",
-      "Value": "ExampleBusinessUnitUpdate-2"
-    },
-    {
-      "Key": "OrganizationBusinessUnitName",
-      "Value": "ExampleOrganizationUpdate-2"
     }
   ]
 }

--- a/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_2_update.json
+++ b/resource-types/awssamples-ec2-importkeypair/python/inputs/inputs_2_update.json
@@ -1,18 +1,4 @@
 {
   "KeyName": "example-keypair-for-contract-tests-2",
-  "PublicKeyMaterial": "{{KeyPairPublicKeyForContractTests}}",
-  "Tags": [
-    {
-      "Key": "Name",
-      "Value": "example-keypair-for-contract-tests-2"
-    },
-    {
-      "Key": "OrganizationName",
-      "Value": "ExampleBusinessUnitUpdate-2a"
-    },
-    {
-      "Key": "OrganizationBusinessUnitName",
-      "Value": "ExampleOrganizationUpdate-2a"
-    }
-  ]
+  "PublicKeyMaterial": "{{KeyPairPublicKeyForContractTests}}"
 }

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
@@ -33,8 +33,8 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.CRITICAL)
 # LOG.setLevel(logging.DEBUG)
 
-# This is name of the resource type
-TYPE_NAME = "AWSSamples::EC2::ImportKeyPair"
+# This is the name of the resource type
+TYPE_NAME = 'AWSSamples::EC2::ImportKeyPair'
 
 resource = Resource(
     TYPE_NAME,
@@ -59,7 +59,7 @@ test_entrypoint = resource.test_entrypoint
 # as part of a resource stabilization logic
 CALLBACK_DELAY_SECONDS = 5
 
-# Define a context for the callback logic.  The value for the "status"
+# Define a context for the callback logic.  The value for the 'status'
 # key in the dictionary below is consumed in is_callback() and in
 # _callback_helper(), that are invoked from a given handler
 CALLBACK_STATUS_IN_PROGRESS = {
@@ -74,14 +74,14 @@ def create_handler(
         callback_context: MutableMapping[str, Any],
 ) -> ProgressEvent:
     """Define the CREATE handler"""
-    LOG.debug("*CREATE handler*")
+    LOG.debug('*CREATE handler*')
 
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
-    LOG.debug(f"Progress status: {progress.status}")
+    LOG.debug(f'Progress status: {progress.status}')
 
     # Check whether or not this is a new invocation of this handler
     if _is_callback(
@@ -92,11 +92,10 @@ def create_handler(
             request,
             callback_context,
             model,
-            is_delete_handler=False,
         )
     # If no callback context is present, then this is a new invocation
     else:
-        LOG.debug("No callback context present")
+        LOG.debug('No callback context present')
 
     try:
         client = _get_session_client(
@@ -143,14 +142,14 @@ def update_handler(
         callback_context: MutableMapping[str, Any],
 ) -> ProgressEvent:
     """Define the UPDATE handler"""
-    LOG.debug("*UPDATE handler*")
+    LOG.debug('*UPDATE handler*')
 
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
-    LOG.debug(f"Progress status: {progress.status}")
+    LOG.debug(f'Progress status: {progress.status}')
 
     # Reusing the callback context logic leveraged in the Read handler
     if _is_callback(
@@ -161,10 +160,9 @@ def update_handler(
             request,
             callback_context,
             model,
-            is_delete_handler=False,
         )
     else:
-        LOG.debug("No callback context present")
+        LOG.debug('No callback context present')
 
     # KeyPairName and KeyPairPublicKey are set as createOnlyProperties
     # in the model; specifying values for such will then result in a
@@ -207,14 +205,14 @@ def delete_handler(
         callback_context: MutableMapping[str, Any],
 ) -> ProgressEvent:
     """Define the DELETE handler"""
-    LOG.debug("*DELETE handler*")
+    LOG.debug('*DELETE handler*')
 
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=None,
     )
-    LOG.debug(f"Progress status: {progress.status}")
+    LOG.debug(f'Progress status: {progress.status}')
 
     # Callback context logic
     if _is_callback(
@@ -228,7 +226,7 @@ def delete_handler(
             is_delete_handler=True,
         )
     else:
-        LOG.debug("No callback context present")
+        LOG.debug('No callback context present')
 
     try:
         client = _get_session_client(
@@ -278,14 +276,14 @@ def read_handler(
         callback_context: MutableMapping[str, Any],
 ) -> ProgressEvent:
     """Define the READ handler"""
-    LOG.debug("*READ handler*")
+    LOG.debug('*READ handler*')
 
     model = request.desiredResourceState
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=model,
     )
-    LOG.debug(f"Progress status: {progress.status}")
+    LOG.debug(f'Progress status: {progress.status}')
 
     try:
         client = _get_session_client(
@@ -314,7 +312,6 @@ def read_handler(
         )
     return _progress_event_success(
         model=model,
-        is_delete_handler=False,
     )
 
 
@@ -325,13 +322,13 @@ def list_handler(
         callback_context: MutableMapping[str, Any],
 ) -> ProgressEvent:
     """Define the LIST handler"""
-    LOG.debug("*LIST handler*")
+    LOG.debug('*LIST handler*')
 
     progress: ProgressEvent = ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
         resourceModel=None,
     )
-    LOG.debug(f"Progress status: {progress.status}")
+    LOG.debug(f'Progress status: {progress.status}')
 
     try:
         client = _get_session_client(
@@ -369,7 +366,7 @@ def list_handler(
         )
     return _progress_event_success(
         models=resource_model_list,
-        is_delete_handler=False,
+        is_list_handler=True,
     )
 
 
@@ -377,7 +374,7 @@ def _get_handler_error_code(
         api_error_code: str,
 ) -> HandlerErrorCode:
     """Get a handler error code for a given service API error code"""
-    LOG.debug("_get_handler_error_code()")
+    LOG.debug('_get_handler_error_code()')
 
     # Handler error codes in the User Guide for Extension Development:
     # https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract-errors.html
@@ -419,7 +416,7 @@ def _progress_event_callback(
         model: ResourceModel,
 ) -> ProgressEvent:
     """Return a ProgressEvent indicating a callback should occur next"""
-    LOG.debug("_progress_event_callback()")
+    LOG.debug('_progress_event_callback()')
 
     return ProgressEvent(
         status=OperationStatus.IN_PROGRESS,
@@ -432,38 +429,39 @@ def _progress_event_callback(
 def _progress_event_success(
         model: ResourceModel = None,
         models: list = None,
-        is_delete_handler=False,
+        is_delete_handler: bool = False,
+        is_list_handler: bool = False,
 ) -> ProgressEvent:
     """Return a ProgressEvent indicating a success"""
-    LOG.debug("_progress_event_success()")
+    LOG.debug('_progress_event_success()')
 
-    if not model and not models and not is_delete_handler:
+    if not model \
+       and not models \
+       and not is_delete_handler \
+       and not is_list_handler:
         raise ValueError(
-            "Specify a model or models, or set is_delete_handler to True",
+            'Model, or models, or is_delete_handler, or is_list_handler unset',
+        )
+    # Otherwise, specify 'is_delete_handler' or 'is_list_handler', not both
+    elif is_delete_handler and is_list_handler:
+        raise ValueError(
+            'Specify either is_delete_handler or is_list_handler, not both',
         )
     # In the case of the Delete handler, just return the status
-    if is_delete_handler:
-        if model or models:
-            raise ValueError(
-                "Specified model data with is_delete_handler set to True",
-            )
+    elif is_delete_handler:
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
         )
-    # Otherwise, specify either 'model' or 'models'
-    if not bool(model) ^ bool(models):
-        raise ValueError(
-            "Specify a model or models when is_delete_handler is set to False",
-        )
-    elif(model):
-        return ProgressEvent(
-            status=OperationStatus.SUCCESS,
-            resourceModel=model,
-        )
-    elif(models):
+    # In the case of the List handler, return the status and 'resourceModels'
+    elif is_list_handler:
         return ProgressEvent(
             status=OperationStatus.SUCCESS,
             resourceModels=models,
+        )
+    else:
+        return ProgressEvent(
+            status=OperationStatus.SUCCESS,
+            resourceModel=model,
         )
 
 
@@ -473,7 +471,7 @@ def _progress_event_failed(
         traceback_content: str = None,
 ) -> ProgressEvent:
     """Log an error, and return a ProgressEvent indicating a failure"""
-    LOG.debug("_progress_event_failed()")
+    LOG.debug('_progress_event_failed()')
 
     # Choose a logging level depending on the handler error code
     log_entry = f"""Error message: {error_message},
@@ -485,7 +483,7 @@ def _progress_event_failed(
         LOG.debug(log_entry)
     return ProgressEvent.failed(
         handler_error_code,
-        f"Error: {error_message}",
+        f'Error: {error_message}',
     )
 
 
@@ -493,7 +491,7 @@ def _is_callback(
         callback_context: MutableMapping[str, Any],
 ) -> bool:
     """Logic to determine whether or not a handler invocation is new"""
-    LOG.debug("_is_callback()")
+    LOG.debug('_is_callback()')
 
     # If there is a callback context status set, then assume this is a
     # handler invocation (e.g., Create handler) for a previous request
@@ -510,7 +508,7 @@ def _callback_helper(
         is_delete_handler: bool = False,
 ) -> ProgressEvent:
     """Define a callback logic used for resource stabilization"""
-    LOG.debug("_callback_helper()")
+    LOG.debug('_callback_helper()')
 
     # Call the Read handler to determine status
     rh = read_handler(
@@ -518,15 +516,14 @@ def _callback_helper(
         request,
         callback_context,
     )
-    LOG.debug(f"Callback: Read handler status: {rh.status}")
+    LOG.debug(f'Callback: Read handler status: {rh.status}')
     # Return success if the Read handler returns success
     if rh.status == OperationStatus.SUCCESS:
         return _progress_event_success(
             model=model,
-            is_delete_handler=False,
         )
     elif rh.errorCode:
-        LOG.debug(f"Callback: Read handler error code: {rh.errorCode}")
+        LOG.debug(f'Callback: Read handler error code: {rh.errorCode}')
         if rh.errorCode == HandlerErrorCode.NotFound and is_delete_handler:
             # Return a success status if the resource is not found
             # (thus, assuming it has been deleted).  The Delete
@@ -548,7 +545,7 @@ def _get_session_client(
         service: str,
 ) -> type:
     """Create and return a session client for a given service"""
-    LOG.debug("_get_session_client()")
+    LOG.debug('_get_session_client()')
 
     if isinstance(
             session,
@@ -566,7 +563,7 @@ def _get_tags_from_desired_resource_tags(
 ) -> list:
     """Create and return a list of tags from
 request.desiredResourceTags"""
-    LOG.debug("_get_tags_from_desired_resource_tags()")
+    LOG.debug('_get_tags_from_desired_resource_tags()')
 
     tags = [
         {
@@ -583,7 +580,7 @@ def _get_tags_from_previous_resource_tags(
 ) -> list:
     """Create and return a list of tags from
 request.previousResourceTags"""
-    LOG.debug("_get_tags_from_previous_resource_tags()")
+    LOG.debug('_get_tags_from_previous_resource_tags()')
 
     tags = [
         {
@@ -599,12 +596,12 @@ def _get_tags_from_model_tags(
         model_tags: list,
 ) -> list:
     """Create and return a list of tags from model.Tags"""
-    LOG.debug("_get_tags_from_model_tags()")
+    LOG.debug('_get_tags_from_model_tags()')
 
     tags = [
         {
-            "Key": model_tag.Key,
-            "Value": model_tag.Value,
+            'Key': model_tag.Key,
+            'Value': model_tag.Value,
         }
         for model_tag in model_tags
     ]
@@ -616,7 +613,7 @@ def _build_tag_list(
         request: ResourceHandlerRequest,
 ) -> list:
     """Build and return a list of resource tags"""
-    LOG.debug("_build_tag_list()")
+    LOG.debug('_build_tag_list()')
 
     tags = []
 
@@ -642,7 +639,7 @@ def _get_tag_lists_diff(
         list_b: list,
 ) -> list:
     """Return a list of tag differences between list_a and list_b"""
-    LOG.debug("_get_tag_lists_diff()")
+    LOG.debug('_get_tag_lists_diff()')
 
     return [list_item for list_item in list_a if list_item not in list_b]
 
@@ -653,7 +650,7 @@ def _update_tags_helper(
         request: ResourceHandlerRequest,
 ) -> None:
     """Update tags on stack update"""
-    LOG.debug("_update_tags_helper()")
+    LOG.debug('_update_tags_helper()')
 
     previous_resource_tags = []
 
@@ -703,7 +700,7 @@ def _import_key_pair_helper(
         request: ResourceHandlerRequest,
 ) -> dict:
     """Create and return a dictionary of arguments for import_key_pair()"""
-    LOG.debug("_import_key_pair_helper()")
+    LOG.debug('_import_key_pair_helper()')
 
     import_key_pair_kwargs = {
         'KeyName': model.KeyName,

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
@@ -339,17 +339,9 @@ def list_handler(
         )
         key_pairs = response['KeyPairs']
         resource_model_list = []
-        for key_pair in key_pairs:
-            resource_model_list_item = ResourceModel(
-                KeyPairId=key_pair['KeyPairId'],
-                KeyFingerprint=key_pair['KeyFingerprint'],
-                KeyName=key_pair['KeyName'],
-                Tags=key_pair['Tags'],
-                PublicKeyMaterial=None,
-            )
-            resource_model_list.append(
-                resource_model_list_item,
-            )
+        resource_model_list = _get_resource_model_list(
+            key_pairs,
+        )
     except botocore.exceptions.ClientError as ce:
         return _progress_event_failed(
             handler_error_code=_get_handler_error_code(
@@ -724,3 +716,24 @@ def _import_key_pair_helper(
             },
         ]
     return import_key_pair_kwargs
+
+
+def _get_resource_model_list(
+        key_pairs: dict,
+) -> list:
+    """Create and return a list of resource model items"""
+    LOG.debug('_get_resource_model_list()')
+
+    resource_model_list = []
+    for key_pair in key_pairs:
+        resource_model_list_item = ResourceModel(
+            KeyPairId=key_pair['KeyPairId'],
+            KeyFingerprint=key_pair['KeyFingerprint'],
+            KeyName=key_pair['KeyName'],
+            Tags=key_pair['Tags'],
+            PublicKeyMaterial=None,
+        )
+        resource_model_list.append(
+            resource_model_list_item,
+        )
+    return resource_model_list

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
@@ -1,12 +1,12 @@
 import logging
 import traceback
-
 from typing import (
     Any,
     MutableMapping,
     Optional,
 )
 
+import botocore
 from cloudformation_cli_python_lib import (
     Action,
     HandlerErrorCode,
@@ -20,8 +20,6 @@ from .models import (
     ResourceHandlerRequest,
     ResourceModel,
 )
-
-import botocore
 
 
 # Use this logger to forward log messages to CloudWatch Logs

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/handlers.py
@@ -532,7 +532,7 @@ def _callback_helper(
 
 def _get_session_client(
         session: Optional[SessionProxy],
-        service: str,
+        service_name: str,
 ) -> type:
     """Create and return a session client for a given service"""
     LOG.debug('_get_session_client()')
@@ -542,7 +542,7 @@ def _get_session_client(
             SessionProxy,
     ):
         client = session.client(
-            'ec2',
+            service_name,
         )
         return client
     return None

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/models.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/models.py
@@ -43,6 +43,7 @@ class ResourceModel(BaseModel):
     KeyPairId: Optional[str]
     KeyFingerprint: Optional[str]
     KeyName: Optional[str]
+    KeyType: Optional[str]
     PublicKeyMaterial: Optional[str]
     Tags: Optional[Sequence["_Tag"]]
 
@@ -59,6 +60,7 @@ class ResourceModel(BaseModel):
             KeyPairId=json_data.get("KeyPairId"),
             KeyFingerprint=json_data.get("KeyFingerprint"),
             KeyName=json_data.get("KeyName"),
+            KeyType=json_data.get("KeyType"),
             PublicKeyMaterial=json_data.get("PublicKeyMaterial"),
             Tags=deserialize_list(json_data.get("Tags"), Tag),
         )

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -1,0 +1,414 @@
+import re
+
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+from functools import (
+    wraps,
+)
+
+from typing import (
+    Any,
+    Callable,
+)
+
+from cloudformation_cli_python_lib import (
+    HandlerErrorCode,
+    OperationStatus,
+    ProgressEvent,
+    SessionProxy,
+)
+
+from .. import handlers
+
+import botocore
+
+
+def handler_assertions(
+        handler_name: str,
+        test_case: str,
+) -> Callable:
+    """Configurable decorator for testing assertions for a given handler"""
+
+    def decorator_function(
+            decorated_function: Callable,
+    ) -> Callable:
+        """Returns a wrapper for the decorated function"""
+
+        @wraps(decorated_function)
+        def decorated_function_wrapper(
+                *args: list,
+                **kwargs: dict,
+        ) -> Any:
+            """Runs the input function and performs test assertions"""
+            decorated_function(
+                *args,
+                **kwargs,
+            )
+            if test_case in [
+                    'operation_status_in_progress',
+                    'operation_status_success',
+            ]:
+                return_value = _mock_call_handler(
+                    handler_name=handler_name,
+                )
+                if handler_name in [
+                        'create',
+                        'update',
+                        'delete',
+                ]:
+                    _operation_status_in_progress_assertions(
+                        return_value=return_value,
+                    )
+                else:
+                    _operation_status_success_assertions(
+                        return_value=return_value,
+                        handler_name=handler_name,
+                    )
+            elif test_case == \
+                    'operation_status_failed_botocore_client_error':
+                # Injecting a mock ValidationError as an example
+                return_value = \
+                    _get_session_client_inject_error_and_call_handler(
+                        handler_name=handler_name,
+                        error_name='ValidationError',
+                    )
+                _operation_status_failed_botocore_client_error_assertions(
+                    return_value=return_value,
+                )
+            elif test_case == 'operation_status_failed_generic_error':
+                return_value = \
+                    _get_session_client_inject_error_and_call_handler(
+                        handler_name=handler_name,
+                    )
+                _operation_status_failed_generic_error_assertions(
+                    return_value=return_value,
+                )
+        return decorated_function_wrapper
+    return decorator_function
+
+
+def _get_session_client_inject_error_and_call_handler(
+        handler_name: str,
+        error_name: str = None,
+) -> ProgressEvent:
+    """Inject a given botocore client error and call a given handler"""
+    if error_name:
+        side_effect = botocore.exceptions.ClientError(
+            {
+                'Error':
+                {
+                    'Code': error_name,
+                    'Message': MagicMock()
+                },
+            },
+            MagicMock(),
+        )
+    else:
+        side_effect = KeyError(
+            MagicMock(),
+        )
+
+    # Determine the base module path name from the resource type name
+    base_module_path_name = re.sub('::', '_', handlers.TYPE_NAME.lower())
+    with patch(
+            f'{base_module_path_name}.handlers._get_session_client',
+            side_effect=side_effect,
+    ):
+        return _mock_call_handler(
+            handler_name=handler_name,
+        )
+
+
+def _mock_call_handler(
+        handler_name: str,
+) -> ProgressEvent:
+    """Helper method to call a given handler for testing"""
+    session = _mock_get_session_client()
+    request = MagicMock(
+        name='request',
+    )
+    callback_context = MagicMock(
+        name='callback_context',
+    )
+    if handler_name == 'create':
+        return handlers.create_handler(
+            session,
+            request,
+            callback_context,
+        )
+    elif handler_name == 'update':
+        return handlers.update_handler(
+            session,
+            request,
+            callback_context,
+        )
+    elif handler_name == 'delete':
+        return handlers.delete_handler(
+            session,
+            request,
+            callback_context,
+        )
+    elif handler_name == 'read':
+        return handlers.read_handler(
+            session,
+            request,
+            callback_context,
+        )
+    elif handler_name == 'list':
+        return handlers.list_handler(
+            session,
+            request,
+            callback_context,
+        )
+    else:
+        raise ValueError(
+            'Specify a valid handler name: create, update, delete, read, list',
+        )
+
+
+def _operation_status_in_progress_assertions(
+        return_value: ProgressEvent,
+) -> None:
+    """Assertions for create, update, and delete operations in progress"""
+    assert isinstance(return_value, ProgressEvent)
+    assert return_value.status == OperationStatus.IN_PROGRESS
+    assert return_value.errorCode is None
+    assert return_value.callbackContext == {
+        'status': OperationStatus.IN_PROGRESS,
+    }
+    assert return_value.callbackDelaySeconds >= 0
+    assert return_value.resourceModel is not None
+    assert return_value.resourceModels is None
+
+
+def _operation_status_success_assertions(
+        return_value: ProgressEvent,
+        handler_name: str,
+) -> None:
+    """Assertions for read, and delete operation status success"""
+    assert isinstance(return_value, ProgressEvent)
+    assert return_value.status == OperationStatus.SUCCESS
+    assert return_value.errorCode is None
+    assert return_value.callbackContext is None
+
+    if handler_name == 'read':
+        assert return_value.resourceModel is not None
+        assert return_value.resourceModels is None
+    elif handler_name == 'list':
+        assert return_value.resourceModel is None
+        assert return_value.resourceModels is not None
+
+
+def _operation_status_failed_botocore_client_error_assertions(
+        return_value: ProgressEvent,
+) -> None:
+    """Assertions for botocore.exceptions.ClientError test cases"""
+    assert isinstance(return_value, ProgressEvent)
+    assert return_value.status == OperationStatus.FAILED
+    assert return_value.errorCode == HandlerErrorCode.InvalidRequest
+    assert return_value.message is not None
+    assert return_value.callbackContext is None
+    assert return_value.callbackDelaySeconds == 0
+    assert return_value.resourceModel is None
+    assert return_value.resourceModels is None
+
+
+def _operation_status_failed_generic_error_assertions(
+        return_value: ProgressEvent,
+) -> None:
+    """Assertions for Exception cases"""
+    assert isinstance(return_value, ProgressEvent)
+    assert return_value.status == OperationStatus.FAILED
+    assert return_value.errorCode == HandlerErrorCode.InternalFailure
+    assert return_value.message is not None
+    assert return_value.callbackContext is None
+    assert return_value.callbackDelaySeconds == 0
+    assert return_value.resourceModel is None
+    assert return_value.resourceModels is None
+
+
+def _mock_get_session_client(
+) -> SessionProxy:
+    """Create and return a mock session client"""
+    session = MagicMock(
+        name='session',
+    )
+    session.client = MagicMock(
+        name='client',
+        return_value=MagicMock(
+            name='client',
+        ),
+    )
+    return SessionProxy(
+        session,
+    )
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_in_progress',
+)
+def test_create_handler_returns_operation_status_in_progress(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+    handlers._import_key_pair_helper = MagicMock()
+
+
+@handler_assertions(
+    handler_name='update',
+    test_case='operation_status_in_progress',
+)
+def test_update_handler_returns_operation_status_in_progress(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+    handlers._update_tags_helper = MagicMock()
+
+
+@handler_assertions(
+    handler_name='delete',
+    test_case='operation_status_in_progress',
+)
+def test_delete_handler_returns_operation_status_in_progress(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='read',
+    test_case='operation_status_success',
+)
+def test_read_handler_returns_operation_status_success(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='list',
+    test_case='operation_status_success',
+)
+def test_list_handler_returns_operation_status_success(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_botocore_client_error',
+)
+def test_create_handler_returns_operation_status_failed_botocore_client_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_generic_error',
+)
+def test_create_handler_returns_operation_status_failed_generic_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='update',
+    test_case='operation_status_failed_botocore_client_error',
+)
+def test_update_handler_returns_operation_status_failed_botocore_client_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='update',
+    test_case='operation_status_failed_generic_error',
+)
+def test_update_handler_returns_operation_status_failed_generic_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='delete',
+    test_case='operation_status_failed_botocore_client_error',
+)
+def test_delete_handler_returns_operation_status_failed_botocore_client_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='delete',
+    test_case='operation_status_failed_generic_error',
+)
+def test_delete_handler_returns_operation_status_failed_generic_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='read',
+    test_case='operation_status_failed_botocore_client_error',
+)
+def test_read_handler_returns_operation_status_failed_botocore_client_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='read',
+    test_case='operation_status_failed_generic_error',
+)
+def test_read_handler_returns_operation_status_failed_generic_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='list',
+    test_case='operation_status_failed_botocore_client_error',
+)
+def test_list_handler_returns_operation_status_failed_botocore_client_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='list',
+    test_case='operation_status_failed_generic_error',
+)
+def test_list_handler_returns_operation_status_failed_generic_error(
+) -> None:
+    session = _mock_get_session_client()
+    client = session
+    assert isinstance(client, SessionProxy)

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -329,6 +329,7 @@ def _get_mock_model(
         KeyPairId='mock-key-pair-id',
         KeyFingerprint='mock-key-fingerprint',
         KeyName='mock-key-name',
+        KeyType='mock-key-type',
         Tags=_get_mock_model_tags_list(),
         PublicKeyMaterial='mock-public-key-material',
     )
@@ -364,6 +365,7 @@ def _get_mock_key_pair_dict(
                 'KeyPairId': 'mock-key-pair-1',
                 'KeyFingerprint': 'mock-key-fingerprint-1',
                 'KeyName': 'mock-key-pair-name-1',
+                'KeyType': 'mock-key-pair-type-1',
                 'Tags': [
                     {
                         'Key': 'mock-key-1',
@@ -375,6 +377,7 @@ def _get_mock_key_pair_dict(
                 'KeyPairId': 'mock-key-pair-2',
                 'KeyFingerprint': 'mock-key-fingerprint-2',
                 'KeyName': 'mock-key-pair-name-2',
+                'KeyType': 'mock-key-pair-type-2',
                 'Tags': [
                     {
                         'Key': 'mock-key-2',
@@ -723,6 +726,24 @@ def test__callback_helper_read_handler_not_found_error_and_is_delete_handler(
         assert return_value.status == OperationStatus.SUCCESS
 
 
+def test__callback_helper_read_handler_not_found_error(
+) -> None:
+    with patch(
+            f'{BASE_MODULE_PATH_NAME}.handlers.read_handler',
+            return_value=ProgressEvent(
+                status=OperationStatus.FAILED,
+                errorCode=HandlerErrorCode.NotFound,
+            ),
+    ):
+        return_value = handlers._callback_helper(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert return_value.status == OperationStatus.FAILED
+
+
 def test__callback_helper_progress_event_callback(
 ) -> None:
     with patch(
@@ -842,18 +863,26 @@ def test__get_resource_model_list(
             KeyPairId='mock-key-pair-1',
             KeyFingerprint='mock-key-fingerprint-1',
             KeyName='mock-key-pair-name-1',
+            KeyType='mock-key-pair-type-1',
             PublicKeyMaterial=None,
             Tags=[
-                {'Key': 'mock-key-1', 'Value': 'mock-value-1'},
+                Tag(
+                    Key='mock-key-1',
+                    Value='mock-value-1',
+                )
             ]
         ),
         ResourceModel(
             KeyPairId='mock-key-pair-2',
             KeyFingerprint='mock-key-fingerprint-2',
             KeyName='mock-key-pair-name-2',
+            KeyType='mock-key-pair-type-2',
             PublicKeyMaterial=None,
             Tags=[
-                {'Key': 'mock-key-2', 'Value': 'mock-value-2'},
+                Tag(
+                    Key='mock-key-2',
+                    Value='mock-value-2',
+                )
             ]
         ),
     ]

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -1,19 +1,17 @@
 import re
-
+from functools import (
+    wraps,
+)
 from unittest.mock import (
     MagicMock,
     patch,
 )
-
-from functools import (
-    wraps,
-)
-
 from typing import (
     Any,
     Callable,
 )
 
+import botocore
 from cloudformation_cli_python_lib import (
     HandlerErrorCode,
     OperationStatus,
@@ -26,10 +24,7 @@ from .. models import (
     ResourceModel,
     Tag,
 )
-
 from .. import handlers
-
-import botocore
 
 
 # Determine the base module path name from the resource type name;
@@ -48,14 +43,14 @@ def handler_assertions(
     def decorator_function(
             decorated_function: Callable,
     ) -> Callable:
-        """Returns a wrapper for the decorated function"""
+        """Return a wrapper for the decorated function"""
 
         @wraps(decorated_function)
         def decorated_function_wrapper(
                 *args: list,
                 **kwargs: dict,
         ) -> Any:
-            """Runs the input function and performs test assertions"""
+            """Run the input function and perform test assertions"""
             decorated_function(
                 *args,
                 **kwargs,
@@ -274,9 +269,21 @@ def _operation_status_failed_generic_error_assertions(
 
 def _mock_get_session_proxy(
 ) -> SessionProxy:
-    """Create and return a mock SessionProxy"""
+    """Create and return a mock SessionProxy with a mock session client"""
+    # Create a mock session
+    session = MagicMock(
+        name='session',
+    )
+    # Create a mock session client
+    session.client = MagicMock(
+        name='client',
+        return_value=MagicMock(
+            name='client',
+        ),
+    )
+    # Return a SessionProxy with the mock session and client
     return SessionProxy(
-        MagicMock(),
+        session,
     )
 
 
@@ -387,8 +394,10 @@ def _get_mock_key_pair_dict(
 def test_create_handler_returns_operation_status_in_progress(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -398,8 +407,10 @@ def test_create_handler_returns_operation_status_in_progress(
 def test_update_handler_returns_operation_status_in_progress(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -409,8 +420,10 @@ def test_update_handler_returns_operation_status_in_progress(
 def test_delete_handler_returns_operation_status_in_progress(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -420,8 +433,10 @@ def test_delete_handler_returns_operation_status_in_progress(
 def test_read_handler_returns_operation_status_success(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -431,8 +446,10 @@ def test_read_handler_returns_operation_status_success(
 def test_list_handler_returns_operation_status_success(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -443,8 +460,10 @@ def test_list_handler_returns_operation_status_success(
 def test_create_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -454,8 +473,10 @@ def test_create_handler_returns_operation_status_failed_botocore_client_error(
 def test_create_handler_returns_operation_status_failed_generic_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -466,8 +487,10 @@ def test_create_handler_returns_operation_status_failed_generic_error(
 def test_update_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -477,8 +500,10 @@ def test_update_handler_returns_operation_status_failed_botocore_client_error(
 def test_update_handler_returns_operation_status_failed_generic_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -489,8 +514,10 @@ def test_update_handler_returns_operation_status_failed_generic_error(
 def test_delete_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -500,8 +527,10 @@ def test_delete_handler_returns_operation_status_failed_botocore_client_error(
 def test_delete_handler_returns_operation_status_failed_generic_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -512,8 +541,10 @@ def test_delete_handler_returns_operation_status_failed_generic_error(
 def test_read_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -523,8 +554,10 @@ def test_read_handler_returns_operation_status_failed_botocore_client_error(
 def test_read_handler_returns_operation_status_failed_generic_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -535,8 +568,10 @@ def test_read_handler_returns_operation_status_failed_generic_error(
 def test_list_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -546,8 +581,10 @@ def test_list_handler_returns_operation_status_failed_botocore_client_error(
 def test_list_handler_returns_operation_status_failed_generic_error(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -558,8 +595,10 @@ def test_list_handler_returns_operation_status_failed_generic_error(
 def test_list_handler_returns_operation_status_failed_not_found(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -570,8 +609,10 @@ def test_list_handler_returns_operation_status_failed_not_found(
 def test_list_handler_returns_operation_status_failed_duplicate(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -582,8 +623,10 @@ def test_list_handler_returns_operation_status_failed_duplicate(
 def test_list_handler_returns_operation_status_failed_key_pair_limit_exceeded(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -594,8 +637,10 @@ def test_list_handler_returns_operation_status_failed_key_pair_limit_exceeded(
 def test_list_handler_returns_operation_status_failed_request_limit_exceeded(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 @handler_assertions(
@@ -606,8 +651,10 @@ def test_list_handler_returns_operation_status_failed_request_limit_exceeded(
 def test_list_handler_returns_operation_status_failed_general_service(
 ) -> None:
     session = _mock_get_session_proxy()
-    client = session
-    assert isinstance(client, SessionProxy)
+    assert isinstance(
+        session,
+        SessionProxy,
+    )
 
 
 def test__progress_event_success_no_parameters_provided(
@@ -727,7 +774,8 @@ def test__get_tag_lists_diff(
 
 def test__update_tags_helper(
 ) -> None:
-    client = _mock_get_session_proxy()
+    session = _mock_get_session_proxy()
+    client = session.client
     client.create_tags = MagicMock(
         name='create_tags',
         return_value={},

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -740,6 +740,19 @@ def test__callback_helper_progress_event_callback(
         assert return_value.status == OperationStatus.IN_PROGRESS
 
 
+def test__get_session_client_session_is_instance_of_session_proxy(
+) -> None:
+    return_value = handlers._get_session_client(
+        _mock_get_session_proxy(),
+        MagicMock(),
+    )
+    assert return_value is not None
+    assert isinstance(
+        return_value,
+        MagicMock,
+    )
+
+
 def test__get_session_client_session_not_instance_of_session_proxy(
 ) -> None:
     assert handlers._get_session_client(

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -21,14 +21,27 @@ from cloudformation_cli_python_lib import (
     SessionProxy,
 )
 
+from .. models import (
+    ResourceHandlerRequest,
+    ResourceModel,
+    Tag,
+)
+
 from .. import handlers
 
 import botocore
 
 
+# Determine the base module path name from the resource type name;
+# using this value for patching during tests
+BASE_MODULE_PATH_NAME = re.sub('::', '_', handlers.TYPE_NAME.lower())
+
+
+# Test helpers
 def handler_assertions(
         handler_name: str,
         test_case: str,
+        error_name: str = None,
 ) -> Callable:
     """Configurable decorator for testing assertions for a given handler"""
 
@@ -69,14 +82,15 @@ def handler_assertions(
                     )
             elif test_case == \
                     'operation_status_failed_botocore_client_error':
-                # Injecting a mock ValidationError as an example
+                # Injecting a mock botocore client error as an example
                 return_value = \
                     _get_session_client_inject_error_and_call_handler(
                         handler_name=handler_name,
-                        error_name='ValidationError',
+                        error_name=error_name,
                     )
                 _operation_status_failed_botocore_client_error_assertions(
                     return_value=return_value,
+                    error_name=error_name,
                 )
             elif test_case == 'operation_status_failed_generic_error':
                 return_value = \
@@ -97,24 +111,21 @@ def _get_session_client_inject_error_and_call_handler(
     """Inject a given botocore client error and call a given handler"""
     if error_name:
         side_effect = botocore.exceptions.ClientError(
-            {
-                'Error':
-                {
+            error_response={
+                'Error': {
                     'Code': error_name,
-                    'Message': MagicMock()
+                    'Message': MagicMock(),
                 },
             },
-            MagicMock(),
+            operation_name=MagicMock(),
         )
     else:
         side_effect = KeyError(
             MagicMock(),
         )
 
-    # Determine the base module path name from the resource type name
-    base_module_path_name = re.sub('::', '_', handlers.TYPE_NAME.lower())
     with patch(
-            f'{base_module_path_name}.handlers._get_session_client',
+            f'{BASE_MODULE_PATH_NAME}.handlers._get_session_client',
             side_effect=side_effect,
     ):
         return _mock_call_handler(
@@ -126,7 +137,7 @@ def _mock_call_handler(
         handler_name: str,
 ) -> ProgressEvent:
     """Helper method to call a given handler for testing"""
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     request = MagicMock(
         name='request',
     )
@@ -134,17 +145,25 @@ def _mock_call_handler(
         name='callback_context',
     )
     if handler_name == 'create':
-        return handlers.create_handler(
-            session,
-            request,
-            callback_context,
-        )
+        with patch(
+                f'{BASE_MODULE_PATH_NAME}.handlers._import_key_pair_helper',
+                return_value=MagicMock(),
+        ):
+            return handlers.create_handler(
+                session,
+                request,
+                callback_context,
+            )
     elif handler_name == 'update':
-        return handlers.update_handler(
-            session,
-            request,
-            callback_context,
-        )
+        with patch(
+                f'{BASE_MODULE_PATH_NAME}.handlers._update_tags_helper',
+                return_value=MagicMock(),
+        ):
+            return handlers.update_handler(
+                session,
+                request,
+                callback_context,
+            )
     elif handler_name == 'delete':
         return handlers.delete_handler(
             session,
@@ -204,11 +223,34 @@ def _operation_status_success_assertions(
 
 def _operation_status_failed_botocore_client_error_assertions(
         return_value: ProgressEvent,
+        error_name: str,
 ) -> None:
     """Assertions for botocore.exceptions.ClientError test cases"""
+    expected_errors_map = {
+        'InvalidKeyPair.NotFound': HandlerErrorCode.NotFound,
+        'InvalidKeyPair.Duplicate': HandlerErrorCode.AlreadyExists,
+        'InvalidKey.Format': HandlerErrorCode.InvalidRequest,
+        'InvalidKeyPair.Format': HandlerErrorCode.InvalidRequest,
+        'InvalidParameter': HandlerErrorCode.InvalidRequest,
+        'InvalidParameterCombination': HandlerErrorCode.InvalidRequest,
+        'InvalidParameterValue': HandlerErrorCode.InvalidRequest,
+        'InvalidTagKey.Malformed': HandlerErrorCode.InvalidRequest,
+        'MissingAction': HandlerErrorCode.InvalidRequest,
+        'MissingParameter': HandlerErrorCode.InvalidRequest,
+        'UnknownParameter': HandlerErrorCode.InvalidRequest,
+        'ValidationError': HandlerErrorCode.InvalidRequest,
+        'KeyPairLimitExceeded': HandlerErrorCode.ServiceLimitExceeded,
+        'TagLimitExceeded': HandlerErrorCode.ServiceLimitExceeded,
+        'ConcurrentTagAccess': HandlerErrorCode.Throttling,
+        'RequestLimitExceeded': HandlerErrorCode.Throttling,
+    }
     assert isinstance(return_value, ProgressEvent)
     assert return_value.status == OperationStatus.FAILED
-    assert return_value.errorCode == HandlerErrorCode.InvalidRequest
+    if error_name == 'example_error':
+        assert return_value.errorCode == \
+            HandlerErrorCode.GeneralServiceException
+    else:
+        assert return_value.errorCode == expected_errors_map[error_name]
     assert return_value.message is not None
     assert return_value.callbackContext is None
     assert return_value.callbackDelaySeconds == 0
@@ -230,33 +272,123 @@ def _operation_status_failed_generic_error_assertions(
     assert return_value.resourceModels is None
 
 
-def _mock_get_session_client(
+def _mock_get_session_proxy(
 ) -> SessionProxy:
-    """Create and return a mock session client"""
-    session = MagicMock(
-        name='session',
-    )
-    session.client = MagicMock(
-        name='client',
-        return_value=MagicMock(
-            name='client',
-        ),
-    )
+    """Create and return a mock SessionProxy"""
     return SessionProxy(
-        session,
+        MagicMock(),
     )
 
 
+def _get_mock_model_tags_list(
+) -> list:
+    """Create and return a list of mock model tags"""
+    return [
+        Tag(
+            Key='mock-key-1',
+            Value='mock-value-1',
+        ),
+        Tag(
+            Key='mock-key-2',
+            Value='mock-value-2',
+        ),
+    ]
+
+
+def _get_mock_tags_dict(
+        sample_name: str = 'sample1',
+) -> dict:
+    """Create and return a dictionary of mock tags"""
+    if sample_name == 'sample1':
+        return {
+            'mock-key-a': 'mock-value-a',
+            'mock-key-b': 'mock-value-b',
+        }
+    elif sample_name == 'sample2':
+        return {
+            'mock-key-c': 'mock-value-c',
+            'mock-key-d': 'mock-value-d',
+        }
+    else:
+        return {
+            'mock-key': 'mock-value',
+        }
+
+
+def _get_mock_model(
+) -> ResourceModel:
+    """Create and return a mock resource model for the example resource type"""
+    return ResourceModel(
+        KeyPairId='mock-key-pair-id',
+        KeyFingerprint='mock-key-fingerprint',
+        KeyName='mock-key-name',
+        Tags=_get_mock_model_tags_list(),
+        PublicKeyMaterial='mock-public-key-material',
+    )
+
+
+def _get_mock_request(
+) -> ResourceHandlerRequest:
+    """Create and return a mock resource handler request"""
+    return ResourceHandlerRequest(
+        clientRequestToken=MagicMock(),
+        desiredResourceState=MagicMock(),
+        previousResourceState=MagicMock(),
+        desiredResourceTags=_get_mock_tags_dict(sample_name='sample1',),
+        previousResourceTags=_get_mock_tags_dict(sample_name='sample2',),
+        systemTags=MagicMock(),
+        previousSystemTags=MagicMock(),
+        awsAccountId=MagicMock(),
+        logicalResourceIdentifier='mock-logical-resource-identifier',
+        typeConfiguration=MagicMock(),
+        nextToken=MagicMock(),
+        region=MagicMock(),
+        awsPartition=MagicMock(),
+        stackId=MagicMock(),
+    )
+
+
+def _get_mock_key_pair_dict(
+) -> dict:
+    """Create and return a dict of mock key pairs"""
+    return {
+        'KeyPairs': [
+            {
+                'KeyPairId': 'mock-key-pair-1',
+                'KeyFingerprint': 'mock-key-fingerprint-1',
+                'KeyName': 'mock-key-pair-name-1',
+                'Tags': [
+                    {
+                        'Key': 'mock-key-1',
+                        'Value': 'mock-value-1'
+                    },
+                ],
+            },
+            {
+                'KeyPairId': 'mock-key-pair-2',
+                'KeyFingerprint': 'mock-key-fingerprint-2',
+                'KeyName': 'mock-key-pair-name-2',
+                'Tags': [
+                    {
+                        'Key': 'mock-key-2',
+                        'Value': 'mock-value-2'
+                    },
+                ],
+            },
+        ],
+    }
+
+
+# Tests
 @handler_assertions(
     handler_name='create',
     test_case='operation_status_in_progress',
 )
 def test_create_handler_returns_operation_status_in_progress(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
-    handlers._import_key_pair_helper = MagicMock()
 
 
 @handler_assertions(
@@ -265,10 +397,9 @@ def test_create_handler_returns_operation_status_in_progress(
 )
 def test_update_handler_returns_operation_status_in_progress(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
-    handlers._update_tags_helper = MagicMock()
 
 
 @handler_assertions(
@@ -277,7 +408,7 @@ def test_update_handler_returns_operation_status_in_progress(
 )
 def test_delete_handler_returns_operation_status_in_progress(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -288,7 +419,7 @@ def test_delete_handler_returns_operation_status_in_progress(
 )
 def test_read_handler_returns_operation_status_success(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -299,7 +430,7 @@ def test_read_handler_returns_operation_status_success(
 )
 def test_list_handler_returns_operation_status_success(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -307,10 +438,11 @@ def test_list_handler_returns_operation_status_success(
 @handler_assertions(
     handler_name='create',
     test_case='operation_status_failed_botocore_client_error',
+    error_name='ValidationError',
 )
 def test_create_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -321,7 +453,7 @@ def test_create_handler_returns_operation_status_failed_botocore_client_error(
 )
 def test_create_handler_returns_operation_status_failed_generic_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -329,10 +461,11 @@ def test_create_handler_returns_operation_status_failed_generic_error(
 @handler_assertions(
     handler_name='update',
     test_case='operation_status_failed_botocore_client_error',
+    error_name='ValidationError',
 )
 def test_update_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -343,7 +476,7 @@ def test_update_handler_returns_operation_status_failed_botocore_client_error(
 )
 def test_update_handler_returns_operation_status_failed_generic_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -351,10 +484,11 @@ def test_update_handler_returns_operation_status_failed_generic_error(
 @handler_assertions(
     handler_name='delete',
     test_case='operation_status_failed_botocore_client_error',
+    error_name='ValidationError',
 )
 def test_delete_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -365,7 +499,7 @@ def test_delete_handler_returns_operation_status_failed_botocore_client_error(
 )
 def test_delete_handler_returns_operation_status_failed_generic_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -373,10 +507,11 @@ def test_delete_handler_returns_operation_status_failed_generic_error(
 @handler_assertions(
     handler_name='read',
     test_case='operation_status_failed_botocore_client_error',
+    error_name='ValidationError',
 )
 def test_read_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -387,7 +522,7 @@ def test_read_handler_returns_operation_status_failed_botocore_client_error(
 )
 def test_read_handler_returns_operation_status_failed_generic_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -395,10 +530,11 @@ def test_read_handler_returns_operation_status_failed_generic_error(
 @handler_assertions(
     handler_name='list',
     test_case='operation_status_failed_botocore_client_error',
+    error_name='ValidationError',
 )
 def test_list_handler_returns_operation_status_failed_botocore_client_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
 
@@ -409,6 +545,314 @@ def test_list_handler_returns_operation_status_failed_botocore_client_error(
 )
 def test_list_handler_returns_operation_status_failed_generic_error(
 ) -> None:
-    session = _mock_get_session_client()
+    session = _mock_get_session_proxy()
     client = session
     assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='read',
+    test_case='operation_status_failed_botocore_client_error',
+    error_name='InvalidKeyPair.NotFound',
+)
+def test_list_handler_returns_operation_status_failed_not_found(
+) -> None:
+    session = _mock_get_session_proxy()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_botocore_client_error',
+    error_name='InvalidKeyPair.Duplicate',
+)
+def test_list_handler_returns_operation_status_failed_duplicate(
+) -> None:
+    session = _mock_get_session_proxy()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_botocore_client_error',
+    error_name='KeyPairLimitExceeded',
+)
+def test_list_handler_returns_operation_status_failed_key_pair_limit_exceeded(
+) -> None:
+    session = _mock_get_session_proxy()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_botocore_client_error',
+    error_name='RequestLimitExceeded',
+)
+def test_list_handler_returns_operation_status_failed_request_limit_exceeded(
+) -> None:
+    session = _mock_get_session_proxy()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+@handler_assertions(
+    handler_name='create',
+    test_case='operation_status_failed_botocore_client_error',
+    error_name='example_error',
+)
+def test_list_handler_returns_operation_status_failed_general_service(
+) -> None:
+    session = _mock_get_session_proxy()
+    client = session
+    assert isinstance(client, SessionProxy)
+
+
+def test__progress_event_success_no_parameters_provided(
+) -> None:
+    try:
+        handlers._progress_event_success()
+    except Exception as e:
+        assert e.__class__.__name__ == 'ValueError'
+
+
+def test__progress_event_success_delete_and_list_handler_parameters_specified(
+) -> None:
+    try:
+        handlers._progress_event_success(
+            is_delete_handler=True,
+            is_list_handler=True,
+        )
+    except Exception as e:
+        assert e.__class__.__name__ == 'ValueError'
+
+
+def test__is_callback(
+) -> None:
+    callback_context = {
+        'status': OperationStatus.IN_PROGRESS,
+    }
+    return_value = handlers._is_callback(
+        callback_context,
+    )
+    assert return_value is True
+
+
+def test__callback_helper_read_handler_success(
+) -> None:
+    with patch(
+            f'{BASE_MODULE_PATH_NAME}.handlers.read_handler',
+            return_value=ProgressEvent(
+                status=OperationStatus.SUCCESS,
+            ),
+    ):
+        return_value = handlers._callback_helper(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert return_value.status == OperationStatus.SUCCESS
+
+
+def test__callback_helper_read_handler_not_found_error_and_is_delete_handler(
+) -> None:
+    with patch(
+            f'{BASE_MODULE_PATH_NAME}.handlers.read_handler',
+            return_value=ProgressEvent(
+                status=OperationStatus.FAILED,
+                errorCode=HandlerErrorCode.NotFound,
+            ),
+    ):
+        return_value = handlers._callback_helper(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            is_delete_handler=True,
+        )
+        assert return_value.status == OperationStatus.SUCCESS
+
+
+def test__callback_helper_progress_event_callback(
+) -> None:
+    with patch(
+            f'{BASE_MODULE_PATH_NAME}.handlers.read_handler',
+            return_value=ProgressEvent(
+                status=OperationStatus.IN_PROGRESS,
+            ),
+    ):
+        return_value = handlers._callback_helper(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert return_value.status == OperationStatus.IN_PROGRESS
+
+
+def test__get_session_client_session_not_instance_of_session_proxy(
+) -> None:
+    assert handlers._get_session_client(
+        MagicMock(),
+        MagicMock(),
+    ) is None
+
+
+def test__get_tags_from_previous_resource_tags(
+) -> None:
+    tags_dict = _get_mock_tags_dict()
+    return_value = handlers._get_tags_from_previous_resource_tags(
+        tags_dict,
+    )
+    expected_value = [
+        {'Key': 'mock-key-a', 'Value': 'mock-value-a'},
+        {'Key': 'mock-key-b', 'Value': 'mock-value-b'},
+    ]
+    assert return_value == expected_value
+
+
+def test__get_tag_lists_diff(
+) -> None:
+    list_a = [1, 2, 3, ]
+    list_b = [3, 4, 5, ]
+    return_value = handlers._get_tag_lists_diff(
+        list_a,
+        list_b,
+    )
+    assert return_value == [1, 2, ]
+
+
+def test__update_tags_helper(
+) -> None:
+    client = _mock_get_session_proxy()
+    client.create_tags = MagicMock(
+        name='create_tags',
+        return_value={},
+    )
+    client.delete_tags = MagicMock(
+        name='delete_tags',
+        return_value={},
+    )
+    return_value = handlers._update_tags_helper(
+        client=client,
+        model=_get_mock_model(),
+        request=_get_mock_request(),
+    )
+    assert return_value is None
+
+
+def test__import_key_pair_helper(
+) -> None:
+    model = _get_mock_model()
+    request = _get_mock_request()
+    return_value = handlers._import_key_pair_helper(
+        model=model,
+        request=request,
+    )
+    expected_value = {
+        'KeyName': 'mock-key-name',
+        'PublicKeyMaterial': b'mock-public-key-material',
+        'TagSpecifications': [
+            {
+                'ResourceType': 'key-pair',
+                'Tags': [
+                    {'Key': 'mock-key-a', 'Value': 'mock-value-a'},
+                    {'Key': 'mock-key-b', 'Value': 'mock-value-b'},
+                    {'Key': 'mock-key-1', 'Value': 'mock-value-1'},
+                    {'Key': 'mock-key-2', 'Value': 'mock-value-2'},
+                ]
+            }
+        ]
+    }
+    assert return_value == expected_value
+
+
+def test__get_resource_model_list(
+) -> None:
+    key_pairs = _get_mock_key_pair_dict()
+    return_value = handlers._get_resource_model_list(
+        key_pairs['KeyPairs'],
+    )
+    expected_value = [
+        ResourceModel(
+            KeyPairId='mock-key-pair-1',
+            KeyFingerprint='mock-key-fingerprint-1',
+            KeyName='mock-key-pair-name-1',
+            PublicKeyMaterial=None,
+            Tags=[
+                {'Key': 'mock-key-1', 'Value': 'mock-value-1'},
+            ]
+        ),
+        ResourceModel(
+            KeyPairId='mock-key-pair-2',
+            KeyFingerprint='mock-key-fingerprint-2',
+            KeyName='mock-key-pair-name-2',
+            PublicKeyMaterial=None,
+            Tags=[
+                {'Key': 'mock-key-2', 'Value': 'mock-value-2'},
+            ]
+        ),
+    ]
+    assert return_value == expected_value
+
+
+def test_create_handler__is_callback(
+) -> None:
+    session = _mock_get_session_proxy()
+    request = MagicMock(
+        name='request',
+    )
+    return_value = handlers.create_handler(
+        session,
+        request,
+        callback_context={'status': OperationStatus.IN_PROGRESS},
+    )
+    assert return_value.status == OperationStatus.SUCCESS
+
+
+def test_update_handler__is_callback(
+) -> None:
+    session = _mock_get_session_proxy()
+    request = MagicMock(
+        name='request',
+    )
+    return_value = handlers.update_handler(
+        session,
+        request,
+        callback_context={'status': OperationStatus.IN_PROGRESS},
+    )
+    assert return_value.status == OperationStatus.SUCCESS
+
+
+def test_delete_handler__is_callback(
+) -> None:
+    session = _mock_get_session_proxy()
+    request = MagicMock(
+        name='request',
+    )
+    return_value = handlers.delete_handler(
+        session,
+        request,
+        callback_context={'status': OperationStatus.IN_PROGRESS},
+    )
+    assert return_value.status == OperationStatus.SUCCESS
+
+
+def test_delete_handler__progress_event_failed(
+) -> None:
+    with patch(
+            f'{BASE_MODULE_PATH_NAME}.handlers.read_handler',
+            return_value=ProgressEvent(
+                status=OperationStatus.FAILED,
+                errorCode=HandlerErrorCode.NotFound,
+            ),
+    ):
+        return_value = handlers.delete_handler(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert return_value.status == OperationStatus.FAILED


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adding unit tests and updates for the AWSSamples::EC2::ImportKeyPair resource type (example using Python).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
