### PR TITLE
Include resource-level tags when determining differences.

### DIFF
--- a/resource-types/awssamples-ec2-importkeypair/python/docs/README.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/docs/README.md
@@ -40,9 +40,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>255</code>
+_Maximum Length_: <code>255</code>
 
 _Pattern_: <code>^[\x00-\x7F]{1,255}$</code>
 
@@ -56,7 +56,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
 _Pattern_: <code>^ssh-[a-z0-9-]+ AAAA[a-zA-Z0-9\+\/]+=*( .*)?$</code>
 
@@ -95,3 +95,4 @@ The MD5 public key fingerprint of the imported key.
 #### KeyType
 
 The type of the key pair.
+

--- a/resource-types/awssamples-ec2-importkeypair/python/docs/tag.md
+++ b/resource-types/awssamples-ec2-importkeypair/python/docs/tag.md
@@ -32,9 +32,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>128</code>
+_Maximum Length_: <code>128</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -46,6 +46,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/models.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/models.py
@@ -1,6 +1,14 @@
 # DO NOT modify this file by hand, changes will be overwritten
-import sys
 from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
 from inspect import getmembers, isclass
 from typing import (
     AbstractSet,
@@ -13,13 +21,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from cloudformation_cli_python_lib.interface import (
-    BaseModel,
-    BaseResourceHandlerRequest,
-)
-from cloudformation_cli_python_lib.recast import recast_object
-from cloudformation_cli_python_lib.utils import deserialize_list
 
 T = TypeVar("T")
 

--- a/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
+++ b/resource-types/awssamples-ec2-importkeypair/python/src/awssamples_ec2_importkeypair/tests/test_handlers.py
@@ -783,19 +783,6 @@ def test__get_session_client_session_not_instance_of_session_proxy() -> None:
     )
 
 
-def test__get_tags_from_previous_resource_tags() -> None:
-    """Run this test."""
-    tags_dict = _get_mock_tags_dict()
-    return_value = handlers._get_tags_from_previous_resource_tags(
-        tags_dict,
-    )
-    expected_value = [
-        {"Key": "mock-key-a", "Value": "mock-value-a"},
-        {"Key": "mock-key-b", "Value": "mock-value-b"},
-    ]
-    assert return_value == expected_value
-
-
 def test__get_tag_lists_diff() -> None:
     """Run this test."""
     list_a = [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Include resource-level tags when determining differences.

### Unit tests excerpts
```
% pytest --cov src
[...]
src/awssamples_ec2_importkeypair/tests/test_handlers.py .....................................                                                                                                        [100%]
[...]
Name                                           Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------------------
src/awssamples_ec2_importkeypair/handlers.py     247      2    106     18    94%
--------------------------------------------------------------------------------
TOTAL                                            247      2    106     18    94%

Required test coverage of 85.0% reached. Total coverage: 94.33%

[...] 37 passed in 1.07s
```

### Contract tests excerpts
```
[...]
13 passed, 2 skipped, 9 deselected, 1 warning in 135.71s (0:02:15) 
[...]
13 passed, 2 skipped, 9 deselected, 1 warning in 132.64s (0:02:12)
[...]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
