### PR TITLE
Update AWSSamples::EC2::ImportKeyPair files to use Python 3.9.

### DIFF
--- a/resource-types/awssamples-ec2-importkeypair/python/.rpdk-config
+++ b/resource-types/awssamples-ec2-importkeypair/python/.rpdk-config
@@ -1,8 +1,8 @@
 {
     "artifact_type": "RESOURCE",
     "typeName": "AWSSamples::EC2::ImportKeyPair",
-    "language": "python37",
-    "runtime": "python3.7",
+    "language": "python39",
+    "runtime": "python3.9",
     "entrypoint": "awssamples_ec2_importkeypair.handlers.resource",
     "testEntrypoint": "awssamples_ec2_importkeypair.handlers.test_entrypoint",
     "settings": {

--- a/resource-types/awssamples-ec2-importkeypair/python/template.yml
+++ b/resource-types/awssamples-ec2-importkeypair/python/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: awssamples_ec2_importkeypair.handlers.resource
-      Runtime: python3.7
+      Runtime: python3.9
       CodeUri: build/
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: awssamples_ec2_importkeypair.handlers.test_entrypoint
-      Runtime: python3.7
+      Runtime: python3.9
       CodeUri: build/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update `AWSSamples::EC2::ImportKeyPair` files to use Python 3.9.

## Contract tests excerpt
### Pass 1
```
[...]
13 passed, 2 skipped, 9 deselected
[...]
```
### Pass 2
```
[...]
13 passed, 2 skipped, 9 deselected
[...]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
