### PR TITLE
fix: give optional array a default value

### DIFF
--- a/hooks/python-hooks/rds-encryption-verify/src/awssamples_rdsencrypt_hook/models.py
+++ b/hooks/python-hooks/rds-encryption-verify/src/awssamples_rdsencrypt_hook/models.py
@@ -35,7 +35,7 @@ class HookHandlerRequest(BaseHookHandlerRequest):
 
 @dataclass
 class TypeConfigurationModel(BaseModel):
-    excludeDBInstanceClassList: Optional[Sequence[Any]]
+    excludeDBInstanceClassList: Optional[Sequence[Any]] = []
 
     @classmethod
     def _deserialize(


### PR DESCRIPTION
If the `excludeDBInstanceClassList` property is not given a value, the hook will fail. This array is marked as optional in the python code. This update assigns a default value to the array.