### PR TITLE
Lambda function examples: fix handler error code typo.

### DIFF
--- a/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/java/src/main/java/com/awssamples/s3versioningenabled/App.java
+++ b/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/java/src/main/java/com/awssamples/s3versioningenabled/App.java
@@ -196,7 +196,7 @@ public class App implements RequestStreamHandler {
             // Default fallback to FAILED in the event of other errors.
             final JSONObject response = new JSONObject();
             response.put("status", "FAILED");
-            response.put("errorCode", "InternalError");
+            response.put("errorCode", "InternalFailure");
             response.put("message", message);
             response.put("callbackContext", Collections.EMPTY_MAP);
             response.put("callbackDelaySeconds", 0);

--- a/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/nodejs/index.mjs
+++ b/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/nodejs/index.mjs
@@ -117,7 +117,7 @@ export const handler = async (event) => {
     // Default fallback to FAILED in the event of other errors.
     payload = {
       'status': 'FAILED',
-      'errorCode': 'InternalError',
+      'errorCode': 'InternalFailure',
       'message': message,
       'callbackContext': null,
       'callbackDelaySeconds': 0,

--- a/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/python/lambda_function.py
+++ b/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/python/lambda_function.py
@@ -148,7 +148,7 @@ def lambda_handler(event, context):
         message = str(exception)
         payload = {
             "status": "FAILED",
-            "errorCode": "InternalError",
+            "errorCode": "InternalFailure",
             "message": message,
             "callbackContext": None,
             "callbackDelaySeconds": 0,

--- a/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/ruby/lambda_function.rb
+++ b/hooks/python-hooks/lambda-function-invoker/example-lambda-functions/s3-versioning-enabled/ruby/lambda_function.rb
@@ -121,7 +121,7 @@ def lambda_handler(event:, context:)
     message = exception.message
     payload = {
       'status': 'FAILED',
-      'errorCode': 'InternalError',
+      'errorCode': 'InternalFailure',
       'message': message,
       'callbackContext': nil,
       'callbackDelaySeconds': 0,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lambda function examples: fix handler error code typo: setting it to `InternalFailure` in some example Lambda functions.

Ran `sam local invoke` to quickly check the overall runs of the target, example functions where the error code above is updated with this pull request:

```
% sam local invoke --event event-success.json
Invoking com.awssamples.s3versioningenabled.App::handleRequest (java17)
[...]
{"callbackDelaySeconds": 0, "errorCode": null, "callbackContext": {}, "message": "Versioning is enabled for the S3 bucket.", "status": "SUCCESS"}
```

```
% sam local invoke --event event-success.json
Invoking index.handler (nodejs20.x)
[...]
{"status": "SUCCESS", "errorCode": null, "message": "Versioning is enabled for the S3 bucket.", "callbackContext": null, "callbackDelaySeconds": 0}
```

```
% sam local invoke --event event-success.json
Invoking lambda_function.lambda_handler (python3.12)
[...]
{"status": "SUCCESS", "errorCode": null, "message": "Versioning is enabled for the S3 bucket.", "callbackContext": null, "callbackDelaySeconds": 0}
```

```
% sam local invoke --event event-success.json
Invoking lambda_function.lambda_handler (ruby3.2)
[...]
{"status": "SUCCESS", "errorCode": null, "message": "Versioning is enabled for the S3 bucket.", "callbackContext": null, "callbackDelaySeconds": 0}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
